### PR TITLE
Notify Slack of project activity

### DIFF
--- a/src/env.py
+++ b/src/env.py
@@ -1,10 +1,15 @@
 from src.dev import *
 
-LOFSM_DIR_PATH = "Audio/LOFSongManager"
-LOFSM_DIR_HASH = "1DEMYiL1aiRJYjf_B3QyKkUbow4xqNaJQ"
-VERSION        = "1.0"
+LOFSM_DIR_PATH         = "Audio/LOFSongManager"
+LOFSM_DIR_HASH         = "1DEMYiL1aiRJYjf_B3QyKkUbow4xqNaJQ"
+VERSION                = "1.0"
+SLACK_WEBHOOK_BASE     = "https://hooks.slack.com/services/T0BQR9YTC/B01DNKG3FFB"
+SLACK_WEBHOOK_ENDPOINT = "3gd2RRCXXzdJu0w7SIM8baeY"
 
 if dev("DEVELOPMENT"):
+
+    SLACK_WEBHOOK_ENDPOINT = "rckKja2hBgMdnMdVDdROdwOD"
+
     if dev("ALT_LOCATION"):
         LOFSM_DIR_PATH = "Audio/LOFSongManagerDev"
         LOFSM_DIR_HASH = "1CsUyd9rRiAxe_T8C1EwONWqrUgJS1blo"

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -503,3 +503,6 @@ def get_username():
         settings = json.load(f)
 
     return settings['user']
+
+def get_nice_username():
+    return get_username().capitalize()

--- a/src/menus/compress_and_upload.py
+++ b/src/menus/compress_and_upload.py
@@ -4,6 +4,7 @@ from src.helpers import *
 from src.Drive import Drive
 from src.hashing import *
 from src.env import LOFSM_DIR_HASH
+from src.slack.notify import Notify as Slack
 
 def compress_and_upload(main_menu):
     # Get extracted project names and list them
@@ -176,6 +177,10 @@ def compress_and_upload(main_menu):
 
     # Clean up after ourselves
     clear_temp()
+
+    # Push a notification to Slack
+    notification = f'{get_nice_username()} uploaded a new version of {project.name}'
+    Slack(notification)
 
     log("Compression and upload complete!")
     pause()

--- a/src/menus/download_and_extract.py
+++ b/src/menus/download_and_extract.py
@@ -5,6 +5,7 @@ from src.helpers import *
 from src.hashing import *
 from src.Drive import Drive
 from src.env import LOFSM_DIR_HASH
+from src.slack.notify import Notify as Slack
 
 def download_and_extract(main_menu):
     print("")
@@ -26,6 +27,10 @@ def download_and_extract(main_menu):
     local_conflict   = Path(f"{project}/{project.stem}_yourversion.song")
     local_version    = Path(f"{project}/{project.stem}.song")
     download_version = Path(f"{temp_project}/{project.stem}.song")
+
+    # Push a notification to Slack
+    notification = f'{get_nice_username()} is working on {project.name}'
+    Slack(notification)
 
     # check hashes
     if not compare_hash(drive, comp_project.name):

--- a/src/slack/notify.py
+++ b/src/slack/notify.py
@@ -1,0 +1,17 @@
+import requests
+import json
+
+
+class Notify:
+
+    endpoint = "https://hooks.slack.com/services/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"
+    headers = { "Content-Type": "application/json" }
+
+    def __init__(self, text):
+        data = { "text": text }
+
+        requests.post(
+            self.endpoint,
+            data = json.dumps(data),
+            headers = self.headers,
+        )

--- a/src/slack/notify.py
+++ b/src/slack/notify.py
@@ -1,17 +1,20 @@
 import requests
 import json
+from src.env import *
 
 
 class Notify:
 
-    endpoint = "https://hooks.slack.com/services/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"
     headers = { "Content-Type": "application/json" }
 
     def __init__(self, text):
         data = { "text": text }
 
         requests.post(
-            self.endpoint,
+            self.endpoint(),
             data = json.dumps(data),
             headers = self.headers,
         )
+
+    def endpoint(self):
+        return f'{SLACK_WEBHOOK_BASE}/{SLACK_WEBHOOK_ENDPOINT}'


### PR DESCRIPTION
Send a Slack notification when a project is uploaded or downloaded. This
helps us to keep tabs on which projects have changed recently, and makes
it easier for us to keep our local projects in sync.