### PR TITLE
Check for updates at startup

### DIFF
--- a/.main.py
+++ b/.main.py
@@ -1,5 +1,7 @@
+from src.helpers import check_for_updates
 from src.menus.main_menu import main_menu
 
 ## MAIN FUNCTION
 if __name__ == '__main__':
+    check_for_updates()
     main_menu()

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -281,6 +281,14 @@ def clear_temp():
         log("Development Mode prevented clear_temp function")
     log("Temp directory cleared!")
 
+def check_for_updates():
+    log("Checking for updates on startup..")
+    perform_update()
+    log("Update Complete!")
+
+def perform_update():
+    git_update() and pip_install()
+
 def git_update():
     if os.name == 'nt':
         git = Path("src/PortableGit/bin/git")
@@ -289,10 +297,16 @@ def git_update():
         os.system("git pull --rebase")
 
 def pip_install():
-    os.system("pip install -r requirements.txt")
+    if os.name == 'nt':
+        os.system('pip install -q -r requirements.txt')
+    else:
+        os.system('pip3 install -q -r requirements.txt')
 
 def pip_freeze():
-    os.system("pip freeze > requirements.txt")
+    if os.name == 'nt':
+        os.system('pip freeze > requirements.txt')
+    else:
+        os.system('pip3 freeze > requirements.txt')
 
 def get_folders(directory):
     directory = Path(directory)

--- a/src/menus/update_program.py
+++ b/src/menus/update_program.py
@@ -7,8 +7,7 @@ def update_program(main_menu):
     display_title("Updates")
 
     log("Checking for updates..")
-    git_update()
-    pip_install()
+    perform_update()
     log("Update Complete!")
 
     pause()


### PR DESCRIPTION
Before the main menu loop begins, check for updates so that new versions
of the program are installed automatically.

This commit also fixes a bug on MacOS, where calling the `pip` command
would fail. When installed via Homebrew, the `python` and `pip` commands
are installed as `python3` and `pip3`. This commit adds a conditional to
account for the difference in naming.