### PR TITLE
Remove Slack endpoints from repository

### DIFF
--- a/src/env.py
+++ b/src/env.py
@@ -3,13 +3,8 @@ from src.dev import *
 LOFSM_DIR_PATH         = "Audio/LOFSongManager"
 LOFSM_DIR_HASH         = "1DEMYiL1aiRJYjf_B3QyKkUbow4xqNaJQ"
 VERSION                = "1.0"
-SLACK_WEBHOOK_BASE     = "https://hooks.slack.com/services/T0BQR9YTC/B01DNKG3FFB"
-SLACK_WEBHOOK_ENDPOINT = "3gd2RRCXXzdJu0w7SIM8baeY"
 
 if dev("DEVELOPMENT"):
-
-    SLACK_WEBHOOK_ENDPOINT = "rckKja2hBgMdnMdVDdROdwOD"
-
     if dev("ALT_LOCATION"):
         LOFSM_DIR_PATH = "Audio/LOFSongManagerDev"
         LOFSM_DIR_HASH = "1CsUyd9rRiAxe_T8C1EwONWqrUgJS1blo"

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -494,6 +494,22 @@ def create_settings():
                     clear_folder(Path("extracted_songs"))
                     clear_folder(Path("compressed_songs"))
 
+        if (not 'slack_endpoint_prod' in settings or
+                not 'slack_endpoint_dev' in settings):
+            clear_screen()
+            endpoints = prompt_for_slack_endpoints()
+
+            settings['slack_endpoint_prod'] = endpoints['production']
+            settings['slack_endpoint_dev']  = endpoints['development']
+
+            with open(settings_file.absolute(), 'w') as f:
+                json.dump(settings, f)
+
+            print('')
+            print('   Finished setting up Slack integration.')
+            print('')
+            pause()
+
     if not settings_file.exists():
         print(':: Welcome!')
         print('')
@@ -512,10 +528,47 @@ def create_settings():
         settings['user']    = name
         settings['version'] = VERSION
 
+        clear_screen()
+        endpoints = prompt_for_slack_endpoints()
+
+        settings['slack_endpoint_prod'] = endpoints['production']
+        settings['slack_endpoint_dev']  = endpoints['development']
+
         with open(settings_file.absolute(), 'w') as f:
             json.dump(settings, f)
 
+        print('')
+        print('   Finished setting up Slack integration.')
+        print('')
+        pause()
+
+def prompt_for_slack_endpoints():
+    print(':: Slack integration setup')
+    print('')
+    print('   Enter the production and development webhook URLs to finish')
+    print('   setting up the Slack integration. The URLs are listed on the')
+    print('   Drive here:')
+    print('')
+    print('     ---> https://drive.google.com/file/d/1xfqoWJN_bLi8E0f7n5eRbWxf1uDALKB7/view?usp=sharing')
+    print('')
+
+    production_endpoint = input('Production endpoint URL: ').lower()
+    development_endpoint = input('Development endpoint URL: ').lower()
+
+    return {
+        'production': production_endpoint,
+        'development': development_endpoint,
+    }
+
 def get_username():
+    settings = get_settings()
+
+    return settings['user']
+
+def get_nice_username():
+    return get_username().capitalize()
+
+def get_settings():
     settings_file = Path('.settings')
     settings      = {}
 
@@ -525,7 +578,4 @@ def get_username():
     with open(settings_file.absolute()) as f:
         settings = json.load(f)
 
-    return settings['user']
-
-def get_nice_username():
-    return get_username().capitalize()
+    return settings

--- a/src/slack/notify.py
+++ b/src/slack/notify.py
@@ -1,6 +1,7 @@
 import requests
 import json
-from src.env import *
+from src.dev import dev
+from src.helpers import get_settings
 
 
 class Notify:
@@ -17,4 +18,12 @@ class Notify:
         )
 
     def endpoint(self):
-        return f'{SLACK_WEBHOOK_BASE}/{SLACK_WEBHOOK_ENDPOINT}'
+        endpoint_key = ''
+        settings = get_settings()
+
+        if dev("DEVELOPMENT"):
+            endpoint_key = 'slack_endpoint_dev'
+        else:
+            endpoint_key = 'slack_endpoint_prod'
+
+        return settings[endpoint_key]


### PR DESCRIPTION
Do not include the Slack endpoint URLs in source code. These URLs are
meant to be kept secret – if the wrong person came across them, they
could theoretically cause some chaos or damage.

Now, the endpoint URLs are obtained out-of-band by prompting the user
directly.

To be safe, all of the webhook endpoint URLs have been regenerated. The
endpoint URLs that previously existed in source code can't really be
erased from the commit history, meaning that someone who was very
motivated could dig up the old endpoint URLs and cause chaos or damage.
We avoid this extremely unlikely situation by regenerating the URLs. The
URLs currently in use have never been committed to the project,
eliminating the possibility of any URLs being found in git or on GitHub.