### PR TITLE
Fix Slack notifications

### DIFF
--- a/src/settings/Settings.py
+++ b/src/settings/Settings.py
@@ -97,7 +97,7 @@ class Settings:
 
         print( "\n".join(output) )
 
-        settings["slack_endpoint_prod"] = input('Production endpoint URL: ').lower()
-        settings["slack_endpoint_dev"]  = input('Development endpoint URL: ').lower()
+        settings["slack_endpoint_prod"] = input('Production endpoint URL: ')
+        settings["slack_endpoint_dev"]  = input('Development endpoint URL: ')
 
         Settings.set(settings)


### PR DESCRIPTION
Slack's webhook endpoint URLs are case-sensitive. Remove unnecessary
string transformation that will cause the endpoint URLs to be saved
incorrectly.